### PR TITLE
chore: adds use client directive to the top of client components

### DIFF
--- a/src/Cell/index.tsx
+++ b/src/Cell/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, {
   createContext,
   forwardRef,

--- a/src/Grid/index.tsx
+++ b/src/Grid/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, {
   useContext,
   createContext,

--- a/src/Settings/index.tsx
+++ b/src/Settings/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { createContext, useContext } from 'react';
 import getColGap from './getColGap';
 import { Settings, SettingsProviderProps } from './types';


### PR DESCRIPTION
This removes the need for consumers of this package to mark every file using Grid/Cell with `use client`